### PR TITLE
Fix incorrect deref

### DIFF
--- a/scripting/tf_econ_data/item_definition.sp
+++ b/scripting/tf_econ_data/item_definition.sp
@@ -232,7 +232,7 @@ int Native_GetItemStaticAttributes(Handle hPlugin, int nParams) {
 	int nAttribs = LoadFromAddress(
 			pItemDef + offs_CEconItemDefinition_AttributeList + offs_CUtlVector_m_size,
 			NumberType_Int32);
-	Address pAttribList = LoadAddressFromAddress(pItemDef + offs_CEconItemDefinition_AttributeList);
+	Address pAttribList = pItemDef + offs_CEconItemDefinition_AttributeList;
 	
 	// struct { attribute_defindex, value } // (TF2)
 	ArrayList attributeList = new ArrayList(2, nAttribs);


### PR DESCRIPTION
Seems to me this deref has always? been invalid.

Either
```cpp
LoadFromAddress(
			pItemDef + offs_CEconItemDefinition_AttributeList + offs_CUtlVector_m_size,
			NumberType_Int32);
```
or
```cpp
LoadAddressFromAddress(pItemDef + offs_CEconItemDefinition_AttributeList);
```
are invalid, but both cannot be correct. One interprets the attribute list as a pointer, the other as a double pointer.

Based on what I'm seeing in sdk2013, its definitively the former so here's a PR fixing that.